### PR TITLE
fix scroll pagination on mobile device

### DIFF
--- a/asset/js/custom.js
+++ b/asset/js/custom.js
@@ -102,7 +102,7 @@ hasTouchTheLimit = false;
 
 $(document).scroll(function(){
 	var _this = $(this),
-	delimiterHeight = $(document).height() - 10,
+	delimiterHeight = $(document).height() - 100,
 	pixelElapse = $(window).height() + _this.scrollTop();
 
 	if(pixelElapse > delimiterHeight){


### PR DESCRIPTION
di HP redmi4A scroll pagination tidak bekerja. 
solusi : Menurunkan nilai `delimiterHeight` jadi mencakup ke layar kecil.